### PR TITLE
fix onnx export

### DIFF
--- a/ModelFormat.py
+++ b/ModelFormat.py
@@ -21,11 +21,12 @@ def save_as_onnx_model(torch_model_path, save_emap=True, img_size = 128):
                   },                         # model input (or a tuple for multiple inputs)
                   output_path,   # where to save the model (can be a file or file-like object)
                   export_params=True,        # store the trained parameter weights inside the model file
-                  opset_version=10,          # the ONNX version to export the model to
+                  opset_version=11,          # the ONNX version to export the model to
                   do_constant_folding=True,  # whether to execute constant folding for optimization
                   input_names = ['target', "source"],   # the model's input names
                   output_names = ['output'], # the model's output names
-                  dynamic_axes={'input' : {0 : 'batch_size'},    # variable length axes
+                  dynamic_axes={'target' : {0 : 'batch_size'},    # variable length axes
+                                'source' : {0 : 'batch_size'},
                                 'output' : {0 : 'batch_size'}})
 
     model = onnx.load(output_path)


### PR DESCRIPTION
This fix TWO important issue with ONNX export:

1.
```
UserWarning: You are trying to export the model with onnx:Resize for ONNX opset version 10. This operator might cause results to not match the expected results by PyTorch.
ONNX's Upsample/Resize operator did not match Pytorch's Interpolation until opset 11. Attributes to determine how to transform the input were added in onnx:Resize in opset 11 to support Pytorch's behavior (like coordinate_transformation_mode and nearest_mode).
We recommend using opset 11 and above for models using this operator.
```

ONNX opset 10 does not match the pytorch resize, and scramles the output. fix to ONNX OPSET 11 solves this problem.

2.
dynamic axis were written incorrctly, I have fixed